### PR TITLE
build: update websockets version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Joel"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-websockets = "^9.1"
+websockets = "^10.3"
 python-dateutil = "^2.8.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Update websockets dependency to latest version.
This will make realtime-py compatible with other libraries using websockets.

Related: #35 