### PR TITLE
fix spelling mistake: set_chanel->set_channel

### DIFF
--- a/docs/realtime/channel.html
+++ b/docs/realtime/channel.html
@@ -41,7 +41,7 @@ class Channel:
     &#34;&#34;&#34;
     `Channel` is an abstraction for a topic listener for an existing socket connection.
     Each Channel has its own topic and a list of event-callbacks that responds to messages.
-    Should only be instantiated through `connection.Socket().set_chanel(topic)`
+    Should only be instantiated through `connection.Socket().set_channel(topic)`
     Topic-Channel has a 1-many relationship.
     &#34;&#34;&#34;
 
@@ -141,7 +141,7 @@ class Channel:
 <dd>
 <div class="desc"><p><code><a title="realtime.channel.Channel" href="#realtime.channel.Channel">Channel</a></code> is an abstraction for a topic listener for an existing socket connection.
 Each Channel has its own topic and a list of event-callbacks that responds to messages.
-Should only be instantiated through <code>connection.Socket().set_chanel(topic)</code>
+Should only be instantiated through <code>connection.Socket().set_channel(topic)</code>
 Topic-Channel has a 1-many relationship.</p>
 <p>:param socket: Socket object
 :param topic: Topic that it subscribes to on the realtime server
@@ -154,7 +154,7 @@ Topic-Channel has a 1-many relationship.</p>
     &#34;&#34;&#34;
     `Channel` is an abstraction for a topic listener for an existing socket connection.
     Each Channel has its own topic and a list of event-callbacks that responds to messages.
-    Should only be instantiated through `connection.Socket().set_chanel(topic)`
+    Should only be instantiated through `connection.Socket().set_channel(topic)`
     Topic-Channel has a 1-many relationship.
     &#34;&#34;&#34;
 

--- a/realtime/channel.py
+++ b/realtime/channel.py
@@ -20,7 +20,7 @@ class Channel:
     """
     `Channel` is an abstraction for a topic listener for an existing socket connection.
     Each Channel has its own topic and a list of event-callbacks that responds to messages.
-    Should only be instantiated through `connection.Socket().set_chanel(topic)`
+    Should only be instantiated through `connection.Socket().set_channel(topic)`
     Topic-Channel has a 1-many relationship.
     """
 


### PR DESCRIPTION
Very minor thing - there were a few occurrences of `set_chanel` when it should be `set_channel` in the docs and in a docstring.