### PR TITLE
fix: correct type argument for cast method during socket initialisation

### DIFF
--- a/realtime/connection.py
+++ b/realtime/connection.py
@@ -3,7 +3,7 @@ import json
 import logging
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable, List, Dict, cast, TypeVar
+from typing import Any, Callable, List, Dict, cast, TypeVar, DefaultDict
 
 import websockets
 from typing_extensions import ParamSpec
@@ -49,7 +49,7 @@ class Socket:
         self.kept_alive = False
         self.auto_reconnect = auto_reconnect
 
-        self.channels = cast(defaultdict[str, List[Channel]], self.channels)
+        self.channels = cast(DefaultDict[str, List[Channel]], self.channels)
 
     @ensure_connection
     def listen(self) -> None:
@@ -74,7 +74,7 @@ class Socket:
 
                 if msg.event == ChannelEvents.reply:
                     continue
-                
+
                 for channel in self.channels.get(msg.topic, []):
                     for cl in channel.listeners:
                         if cl.event in ["*", msg.event]:

--- a/realtime/connection.py
+++ b/realtime/connection.py
@@ -49,7 +49,7 @@ class Socket:
         self.kept_alive = False
         self.auto_reconnect = auto_reconnect
 
-        self.channels = cast(DefaultDict[str, List[Channel]], self.channels)
+        self.channels: DefaultDict[str, List[Channel]] = defaultdict(list)
 
     @ensure_connection
     def listen(self) -> None:

--- a/realtime/connection.py
+++ b/realtime/connection.py
@@ -3,7 +3,7 @@ import json
 import logging
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable, List, Dict, cast, TypeVar, DefaultDict
+from typing import Any, Callable, List, Dict, TypeVar, DefaultDict
 
 import websockets
 from typing_extensions import ParamSpec


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix that corrects the type argument provided to the `cast` method during `Socket` initialisation

## What is the current behavior?

Documented in #58 

## What is the new behavior?

Correctly initialises the `Socket` class

## Additional context

NA
