### PR TITLE
fix: Remove the global logger call from realtime-py

### DIFF
--- a/realtime/connection.py
+++ b/realtime/connection.py
@@ -13,10 +13,9 @@ from realtime.exceptions import NotConnectedError
 from realtime.message import HEARTBEAT_PAYLOAD, PHOENIX_CHANNEL, ChannelEvents, Message
 from realtime.types import Callback, T_ParamSpec, T_Retval
 
-logging.basicConfig(
-    format="%(asctime)s:%(levelname)s - %(message)s", level=logging.INFO
-)
-
+# logging.basicConfig(
+#     format="%(asctime)s:%(levelname)s - %(message)s", level=logging.INFO
+# )
 
 def ensure_connection(func: Callback):
     @wraps(func)


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase-community/realtime-py/issues/87

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
